### PR TITLE
Support closure loggers in @loggable macro

### DIFF
--- a/Tests/SwiftLoggableMacroTests/SwiftLoggableMacroTests.swift
+++ b/Tests/SwiftLoggableMacroTests/SwiftLoggableMacroTests.swift
@@ -88,6 +88,34 @@ final class SwiftLoggableMacroTests: XCTestCase {
         )
     }
 
+    // Test case for a function with a closure logger
+    func testMacroWithClosureLogger() {
+        assertMacroExpansion(
+            """
+            @loggable(logger: { print("LOG: \\($0)") })
+            func multiply(a: Int, b: Int) -> Int {
+                return a * b
+            }
+            """,
+            expandedSource: """
+            func multiply(a: Int, b: Int) -> Int {
+                ({ print("LOG: \\($0)") })("Entering function: multiply")
+                ({ print("LOG: \\($0)") })("Parameter 1 Name: a = \\(a) : of type : Int")
+                ({ print("LOG: \\($0)") })("Parameter 2 Name: b = \\(b) : of type : Int")
+                defer {
+                    ({ print("LOG: \\($0)") })("Exiting function: multiply")
+                }
+                let result = ({
+                    return a * b
+                })()
+                ({ print("LOG: \\($0)") })("Return value: \\(result)")
+                return result
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     // Test case for a function with no parameters
     func testMacroOnFunctionWithNoParameters() {
         assertMacroExpansion(


### PR DESCRIPTION
## Summary
- handle logger arguments as full expressions to support closures
- add regression test for using a closure-based logger

## Testing
- `swift test` *(fails: package uses Swift tools 6.2.0 but installed version is 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68994b2cd0d4832a95a761115c503000